### PR TITLE
Use lighter selection.background

### DIFF
--- a/themes/Framer Syntax-color-theme.json
+++ b/themes/Framer Syntax-color-theme.json
@@ -176,8 +176,8 @@
     "scrollbarSlider.background": "#333",
     "scrollbarSlider.hoverBackground": "#333",
 
-    "selection.background": "#333",
-
+    "selection.background": "#fff",
+    
     "sideBar.background": "#111",
     "sideBar.border": "#111",
     "sideBar.foreground": "#888",


### PR DESCRIPTION
Use a lighter `selection.background` to be able to see the selected text. Fixes #2.

**Result:**

![image](https://user-images.githubusercontent.com/2484832/39183299-cd770290-47bf-11e8-99f3-1334f248ae1c.png)
